### PR TITLE
Fix trimValue when value is object

### DIFF
--- a/.changeset/fair-mangos-collect.md
+++ b/.changeset/fair-mangos-collect.md
@@ -1,0 +1,5 @@
+---
+'@divriots/style-dictionary-to-figma': patch
+---
+
+Fixes trimValue when used on values that are objects.

--- a/src/trim-value.js
+++ b/src/trim-value.js
@@ -4,17 +4,22 @@
 
 /**
  * @param {Obj} obj
+ * @param {boolean} isValueObj
  * @returns {Obj}
  */
-export function trimValue(obj) {
+export function trimValue(obj, isValueObj = false) {
   const newObj = { ...obj };
   Object.keys(newObj).forEach(key => {
-    if (key === 'value') {
-      const val = /** @type {string} */ (newObj[key]);
-      const reg = /^\{(.*)\}$/g;
-      const matches = reg.exec(val);
-      if (matches && matches[1]) {
-        newObj[key] = val.replace('.value', '');
+    if (key === 'value' || isValueObj) {
+      if (typeof newObj[key] === 'string') {
+        const val = /** @type {string} */ (newObj[key]);
+        const reg = /^\{(.*)\}$/g;
+        const matches = reg.exec(val);
+        if (matches && matches[1]) {
+          newObj[key] = val.replace('.value', '');
+        }
+      } else if (typeof newObj[key] === 'object') {
+        newObj[key] = trimValue(/** @type {Obj} */ (newObj[key]), true);
       }
     } else if (typeof newObj[key] === 'object') {
       newObj[key] = trimValue(/** @type {Obj} */ (newObj[key]));

--- a/test/trim-value.test.js
+++ b/test/trim-value.test.js
@@ -55,4 +55,36 @@ describe('trim-value', () => {
 
     expect(trimmedObj).to.eql(expectedObj);
   });
+
+  it('trims away any .value from reference values in nested objects when value is object', () => {
+    const obj = {
+      shadow: {
+        value: {
+          x: '0',
+          y: '1',
+          blur: '2',
+          spread: '0',
+          color: '{color.accent.base.value}',
+          type: 'dropShadow',
+        },
+      },
+    };
+
+    const expectedObj = {
+      shadow: {
+        value: {
+          x: '0',
+          y: '1',
+          blur: '2',
+          spread: '0',
+          color: '{color.accent.base}',
+          type: 'dropShadow',
+        },
+      },
+    };
+
+    const trimmedObj = trimValue(obj);
+
+    expect(trimmedObj).to.eql(expectedObj);
+  });
 });


### PR DESCRIPTION
In style-dictionary, values can be objects (see https://github.com/amzn/style-dictionary/pull/623 for the implementation there). The current trimValue implementation here expects them to always be strings, and throws when it encounters an object.

