### PR TITLE
fix: keep array values as arrays

### DIFF
--- a/.changeset/sweet-rocks-vanish.md
+++ b/.changeset/sweet-rocks-vanish.md
@@ -1,0 +1,5 @@
+---
+'@divriots/style-dictionary-to-figma': patch
+---
+
+Keeps an array-type value as an array. This is useful with boxShadows that can have multiple stacked shadows in a single token.

--- a/src/trim-name.js
+++ b/src/trim-name.js
@@ -13,7 +13,8 @@ export function trimName(obj) {
     if (key === 'name') {
       delete newObj[key];
     } else if (typeof newObj[key] === 'object') {
-      newObj[key] = trimName(/** @type {Obj} */ (newObj[key]));
+      const newValue = trimName(/** @type {Obj} */ (newObj[key]));
+      newObj[key] = Array.isArray(newObj[key]) ? Object.values(newValue) : newValue;
     }
   });
 

--- a/src/trim-value.js
+++ b/src/trim-value.js
@@ -19,7 +19,8 @@ export function trimValue(obj, isValueObj = false) {
           newObj[key] = val.replace('.value', '');
         }
       } else if (typeof newObj[key] === 'object') {
-        newObj[key] = trimValue(/** @type {Obj} */ (newObj[key]), true);
+        const newValue = trimValue(/** @type {Obj} */ (newObj[key]), true);
+        newObj[key] = Array.isArray(newObj[key]) ? Object.values(newValue) : newValue;
       }
     } else if (typeof newObj[key] === 'object') {
       newObj[key] = trimValue(/** @type {Obj} */ (newObj[key]));

--- a/src/use-ref-value.js
+++ b/src/use-ref-value.js
@@ -12,7 +12,8 @@ export function useRefValue(obj) {
     if (key === 'original') {
       newObj.value = /** @type {Obj} */ (newObj[key]).value;
     } else if (typeof newObj[key] === 'object') {
-      newObj[key] = useRefValue(/** @type {Obj} */ (newObj[key]));
+      const newValue = useRefValue(/** @type {Obj} */ (newObj[key]));
+      newObj[key] = Array.isArray(newObj[key]) ? Object.values(newValue) : newValue;
     }
   });
   return newObj;

--- a/test/style-dictionary-to-figma.test.js
+++ b/test/style-dictionary-to-figma.test.js
@@ -17,6 +17,28 @@ describe('style-dictionary-to-figma', () => {
           },
         },
       },
+      boxShadow: {
+        small: {
+          value: [
+            {
+              x: '0',
+              y: '1',
+              blur: '2',
+              spread: '0',
+              color: '{color.accent.base.value}',
+              type: 'dropShadow',
+            },
+            {
+              x: '0',
+              y: '2',
+              blur: '4',
+              spread: '0',
+              color: '{color.accent.base.value}',
+              type: 'dropShadow',
+            },
+          ],
+        },
+      },
     };
 
     const expectedObj = {
@@ -31,6 +53,28 @@ describe('style-dictionary-to-figma', () => {
               value: '{colors.accent.base}',
             },
           },
+        },
+      },
+      boxShadow: {
+        small: {
+          value: [
+            {
+              x: '0',
+              y: '1',
+              blur: '2',
+              spread: '0',
+              color: '{color.accent.base}',
+              type: 'dropShadow',
+            },
+            {
+              x: '0',
+              y: '2',
+              blur: '4',
+              spread: '0',
+              color: '{color.accent.base}',
+              type: 'dropShadow',
+            },
+          ],
         },
       },
     };

--- a/test/trim-value.test.js
+++ b/test/trim-value.test.js
@@ -87,4 +87,56 @@ describe('trim-value', () => {
 
     expect(trimmedObj).to.eql(expectedObj);
   });
+
+  it('trims away any .value from reference values in nested objects when value is array', () => {
+    const obj = {
+      shadow: {
+        value: [
+          {
+            x: '0',
+            y: '1',
+            blur: '2',
+            spread: '0',
+            color: '{color.accent.base.value}',
+            type: 'dropShadow',
+          },
+          {
+            x: '0',
+            y: '2',
+            blur: '4',
+            spread: '0',
+            color: '{color.accent.base.value}',
+            type: 'dropShadow',
+          },
+        ],
+      },
+    };
+
+    const expectedObj = {
+      shadow: {
+        value: [
+          {
+            x: '0',
+            y: '1',
+            blur: '2',
+            spread: '0',
+            color: '{color.accent.base}',
+            type: 'dropShadow',
+          },
+          {
+            x: '0',
+            y: '2',
+            blur: '4',
+            spread: '0',
+            color: '{color.accent.base}',
+            type: 'dropShadow',
+          },
+        ],
+      },
+    };
+
+    const trimmedObj = trimValue(obj);
+
+    expect(trimmedObj).to.eql(expectedObj);
+  });
 });


### PR DESCRIPTION
The previous object fix almost got my exporting code working, but not just yet. The description and tests are quite real, e.g. Figma Tokens accepts multiple shadows in a single boxShadow token, and stores them as arrays.