### PR TITLE
fix: only restore subvalues with refs in objects and arrays

### DIFF
--- a/.changeset/strong-sheep-reply.md
+++ b/.changeset/strong-sheep-reply.md
@@ -1,0 +1,5 @@
+---
+'@divriots/style-dictionary-to-figma': patch
+---
+
+Restore original reference value in objects/arrays for only those items that were originally references. This will keep any other non-reference pretransformed items as intended - previously other transforms were reverted.

--- a/test/use-ref-value.test.js
+++ b/test/use-ref-value.test.js
@@ -74,7 +74,7 @@ describe('trim-name', () => {
       original: {
         value: ['{shadow.core.4}', 'pre-transformed-shadow-2'],
       },
-      value: ['{shadow.core.4}', 'pre-transformed-shadow-2'],
+      value: ['{shadow.core.4}', '0 0 2px rgba(0,0,0,0.6)'],
     };
     const transformedObj2 = useRefValue(obj2);
     expect(transformedObj2).to.eql(expectedObj2);
@@ -85,7 +85,7 @@ describe('trim-name', () => {
       original: {
         value: {
           fontFamily: '{fontFamily.body}',
-          fontWeight: '{fontWeight.regular}',
+          fontWeight: '500',
           lineHeight: '{size.lineHeight.xsmall}',
           fontSize: '{size.font.xsmall}',
         },
@@ -93,7 +93,7 @@ describe('trim-name', () => {
       value: {
         fontFamily: 'Inter',
         fontWeight: 'Medium',
-        lineHeight: '1',
+        lineHeight: 1,
         fontSize: '16px',
       },
     };
@@ -101,14 +101,14 @@ describe('trim-name', () => {
       original: {
         value: {
           fontFamily: '{fontFamily.body}',
-          fontWeight: '{fontWeight.regular}',
+          fontWeight: '500',
           lineHeight: '{size.lineHeight.xsmall}',
           fontSize: '{size.font.xsmall}',
         },
       },
       value: {
         fontFamily: '{fontFamily.body}',
-        fontWeight: '{fontWeight.regular}',
+        fontWeight: 'Medium',
         lineHeight: '{size.lineHeight.xsmall}',
         fontSize: '{size.font.xsmall}',
       },


### PR DESCRIPTION
Hey again 👋 

We have a transform that replaces the numeric font-weights with the corresponding keyword. In one special case, the weight itself is not a separate token reference, it is defined directly in a typography style object.

Source is something like this:
```json
{
  "small": {
    "value": {
      "fontFamily": "{fontFamily.code}",
      "fontWeight": "700",
      "lineHeight": "{size.lineHeight.xsmall}",
      "fontSize": "{size.font.xsmall}"
    }
  }
}
```

Expected output is:

```json
{
  "small": {
    "value": {
      "fontFamily": "{fontFamily.code}",
      "fontWeight": "Bold",
      "lineHeight": "{size.lineHeight.xsmall}",
      "fontSize": "{size.font.xsmall}"
    }
  }
}
```

Now, our transform correctly replaces this inside of the object, but the refs restoring function ignores that, as it blindly replaces the entire object when any of the object keys are using refs.

So here's a fix for that, should recursively manage deeper object values as well, if they are a thing.